### PR TITLE
install snapd snap in bootstrap and join script

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,6 +8,7 @@ export BASH_XTRACEFD="19"
 set -ex
 
 cd /opt/canonical-k8s
+snap ack snapd.assert && sudo snap install ./snapd.snap
 snap ack core20.assert && sudo snap install ./core20.snap --classic
 snap ack k8s.assert && sudo snap install ./k8s.snap --classic
 

--- a/scripts/join.sh
+++ b/scripts/join.sh
@@ -10,6 +10,7 @@ set -ex
 token=$1
 
 cd /opt/canonical-k8s
+snap ack snapd.assert && sudo snap install ./snapd.snap
 snap ack core20.assert && sudo snap install ./core20.snap
 snap ack k8s.assert && sudo snap install ./k8s.snap --classic
 


### PR DESCRIPTION
This change is to ensure K8s snap installation in fully airgapped environments.