### PR TITLE
feat(PE-9015): add extra-node-etcd-args passthrough for Canonical k8s

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kairos-io/provider-canonical
 go 1.26.4
 
 require (
-	github.com/canonical/k8s-snap-api v1.0.23
+	github.com/canonical/k8s-snap-api v1.1.0
 	github.com/kairos-io/kairos-sdk v0.7.2
 	github.com/mudler/go-pluggable v0.0.0-20230126220627-7710299a0ae5
 	github.com/mudler/yip v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/alecthomas/assert/v2 v2.3.0 h1:mAsH2wmvjsuvyBvAmCtm7zFsBlb8mIHx5ySLVd
 github.com/alecthomas/assert/v2 v2.3.0/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
 github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
 github.com/alecthomas/repr v0.2.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/canonical/k8s-snap-api v1.0.23 h1:P2yYaUnLB1FUjpiOjad3LfuqZRfsdoHMWwmpdmqNmm4=
-github.com/canonical/k8s-snap-api v1.0.23/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
+github.com/canonical/k8s-snap-api v1.1.0 h1:RME41bv1t8TY4IIEoVs8JOqJO5C9UW+CC/TEPvWKXnA=
+github.com/canonical/k8s-snap-api v1.1.0/go.mod h1:kdXBgGo5TF93NJYHfa1bfKIzEIgE1oQriFHcVoVQUX8=
 github.com/chuckpreslar/emission v0.0.0-20170206194824-a7ddd980baf9 h1:xz6Nv3zcwO2Lila35hcb0QloCQsc38Al13RNEzWRpX4=
 github.com/chuckpreslar/emission v0.0.0-20170206194824-a7ddd980baf9/go.mod h1:2wSM9zJkl1UQEFZgSd68NfCgRz1VL1jzy/RjCg+ULrs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/stages/reconfigure.go
+++ b/pkg/stages/reconfigure.go
@@ -22,66 +22,92 @@ import (
 
 func getBootstrapReconfigureStage(config apiv1.BootstrapConfig) []yip.Stage {
 	return getReconfigureStage(config.ExtraNodeKubeAPIServerArgs, config.ExtraNodeKubeControllerManagerArgs,
-		config.ExtraNodeKubeSchedulerArgs, config.ExtraNodeKubeProxyArgs, config.ExtraNodeKubeletArgs)
+		config.ExtraNodeKubeSchedulerArgs, config.ExtraNodeKubeProxyArgs, config.ExtraNodeKubeletArgs,
+		config.ExtraNodeEtcdArgs)
 }
 
 func getControlPlaneReconfigureStage(config apiv1.ControlPlaneJoinConfig) []yip.Stage {
 	return getReconfigureStage(config.ExtraNodeKubeAPIServerArgs, config.ExtraNodeKubeControllerManagerArgs,
-		config.ExtraNodeKubeSchedulerArgs, config.ExtraNodeKubeProxyArgs, config.ExtraNodeKubeletArgs)
+		config.ExtraNodeKubeSchedulerArgs, config.ExtraNodeKubeProxyArgs, config.ExtraNodeKubeletArgs,
+		config.ExtraNodeEtcdArgs)
 }
 
-func getReconfigureStage(apiserver, controller, scheduler, kubeProxy, kubelet map[string]*string) []yip.Stage {
+func getReconfigureStage(apiserver, controller, scheduler, kubeProxy, kubelet, etcd map[string]*string) []yip.Stage {
 	return []yip.Stage{
-		getReconfigureFileStage(apiserver, controller, scheduler, kubeProxy, kubelet),
-		getReconfigureServiceRestartStage(),
+		getReconfigureFileStage(apiserver, controller, scheduler, kubeProxy, kubelet, etcd),
+		getReconfigureServiceRestartStage(etcd),
 	}
 }
 
-func getReconfigureFileStage(apiserver, controller, scheduler, kubeProxy, kubelet map[string]*string) yip.Stage {
-	return yip.Stage{
-		Name: "Regenerate Kube Components Args Files",
-		Files: []yip.File{
-			{
-				Path:        filepath.Join(domain.KubeComponentsArgsPath, "kube-apiserver"),
-				Permissions: 0600,
-				Content:     getApiserverArgs(apiserver),
-			},
-			{
-				Path:        filepath.Join(domain.KubeComponentsArgsPath, "kube-controller-manager"),
-				Permissions: 0600,
-				Content:     getKubeControllerArgs(controller),
-			},
-			{
-				Path:        filepath.Join(domain.KubeComponentsArgsPath, "kube-scheduler"),
-				Permissions: 0600,
-				Content:     getKubeSchedulerArgs(scheduler),
-			},
-			{
-				Path:        filepath.Join(domain.KubeComponentsArgsPath, "kube-proxy"),
-				Permissions: 0600,
-				Content:     getKubeProxyArgs(kubeProxy),
-			},
-			{
-				Path:        filepath.Join(domain.KubeComponentsArgsPath, "kubelet"),
-				Permissions: 0600,
-				Content:     getKubeletArgs(kubelet),
-			},
+func getReconfigureFileStage(apiserver, controller, scheduler, kubeProxy, kubelet, etcd map[string]*string) yip.Stage {
+	files := []yip.File{
+		{
+			Path:        filepath.Join(domain.KubeComponentsArgsPath, "kube-apiserver"),
+			Permissions: 0600,
+			Content:     getApiserverArgs(apiserver),
 		},
+		{
+			Path:        filepath.Join(domain.KubeComponentsArgsPath, "kube-controller-manager"),
+			Permissions: 0600,
+			Content:     getKubeControllerArgs(controller),
+		},
+		{
+			Path:        filepath.Join(domain.KubeComponentsArgsPath, "kube-scheduler"),
+			Permissions: 0600,
+			Content:     getKubeSchedulerArgs(scheduler),
+		},
+		{
+			Path:        filepath.Join(domain.KubeComponentsArgsPath, "kube-proxy"),
+			Permissions: 0600,
+			Content:     getKubeProxyArgs(kubeProxy),
+		},
+		{
+			Path:        filepath.Join(domain.KubeComponentsArgsPath, "kubelet"),
+			Permissions: 0600,
+			Content:     getKubeletArgs(kubelet),
+		},
+	}
+
+	// etcd is opt-in: only rewrite its args file when the user actually set
+	// extra-node-etcd-args, so existing clusters that don't use the feature
+	// see no etcd churn on a provider-canonical upgrade (etcd is the datastore).
+	if len(etcd) > 0 {
+		files = append(files, yip.File{
+			Path:        filepath.Join(domain.KubeComponentsArgsPath, "etcd"),
+			Permissions: 0600,
+			Content:     getEtcdArgs(etcd),
+		})
+	}
+
+	return yip.Stage{
+		Name:  "Regenerate Kube Components Args Files",
+		Files: files,
 	}
 }
 
-func getReconfigureServiceRestartStage() yip.Stage {
+func getReconfigureServiceRestartStage(etcd map[string]*string) yip.Stage {
+	commands := []string{
+		"systemctl daemon-reload",
+	}
+
+	// Restart etcd first (before the kube components depend on it) and only
+	// when etcd args were supplied — see getReconfigureFileStage.
+	if len(etcd) > 0 {
+		commands = append(commands, "systemctl restart snap.k8s.etcd.service")
+	}
+
+	commands = append(commands,
+		"systemctl restart snap.k8s.containerd.service",
+		"systemctl restart snap.k8s.kube-apiserver.service",
+		"systemctl restart snap.k8s.kube-controller-manager.service",
+		"systemctl restart snap.k8s.kube-scheduler.service",
+		"systemctl restart snap.k8s.kube-proxy.service",
+		"systemctl restart snap.k8s.kubelet.service",
+	)
+
 	return yip.Stage{
-		Name: "Restart Kube Components Services",
-		Commands: []string{
-			"systemctl daemon-reload",
-			"systemctl restart snap.k8s.containerd.service",
-			"systemctl restart snap.k8s.kube-apiserver.service",
-			"systemctl restart snap.k8s.kube-controller-manager.service",
-			"systemctl restart snap.k8s.kube-scheduler.service",
-			"systemctl restart snap.k8s.kube-proxy.service",
-			"systemctl restart snap.k8s.kubelet.service",
-		},
+		Name:     "Restart Kube Components Services",
+		Commands: commands,
 	}
 }
 
@@ -238,6 +264,10 @@ func getKubeProxyArgs(updatedArgs map[string]*string) string {
 
 func getKubeletArgs(updatedArgs map[string]*string) string {
 	return getArgs(updatedArgs, "kubelet")
+}
+
+func getEtcdArgs(updatedArgs map[string]*string) string {
+	return getArgs(updatedArgs, "etcd")
 }
 
 func getArgs(updatedArgs map[string]*string, serviceName string) string {

--- a/pkg/stages/reconfigure_test.go
+++ b/pkg/stages/reconfigure_test.go
@@ -266,6 +266,144 @@ func TestGetArgs(t *testing.T) {
 	})
 }
 
+func TestGetEtcdArgs(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("merges new etcd args over the existing args file", func(t *testing.T) {
+		fileContent := `--advertise-client-urls=https://10.10.132.153:2379
+--data-dir=/var/snap/k8s/common/var/lib/etcd/data`
+
+		testFS, cleanup, err := vfst.NewTestFS(map[string]interface{}{
+			filepath.Join(domain.KubeComponentsArgsPath, "etcd"): fileContent,
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		defer cleanup()
+
+		originalFS := fs.OSFS
+		fs.OSFS = testFS
+		defer func() { fs.OSFS = originalFS }()
+
+		metricsURL := "http://0.0.0.0:2381"
+		updatedArgs := map[string]*string{
+			"--listen-metrics-urls": &metricsURL,
+		}
+
+		result := getEtcdArgs(updatedArgs)
+		expectedLines := []string{
+			"--advertise-client-urls=https://10.10.132.153:2379",
+			"--data-dir=/var/snap/k8s/common/var/lib/etcd/data",
+			"--listen-metrics-urls=http://0.0.0.0:2381",
+		}
+
+		resultLines := strings.Split(result, "\n")
+		sort.Strings(resultLines)
+		sort.Strings(expectedLines)
+
+		g.Expect(resultLines).To(Equal(expectedLines))
+	})
+}
+
+func TestGetReconfigureServiceRestartStage(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("restarts etcd before the other kube components when etcd args are set", func(t *testing.T) {
+		metricsURL := "http://0.0.0.0:2381"
+		etcd := map[string]*string{"--listen-metrics-urls": &metricsURL}
+
+		stage := getReconfigureServiceRestartStage(etcd)
+
+		g.Expect(stage.Commands).To(ContainElement("systemctl restart snap.k8s.etcd.service"))
+
+		etcdIdx := indexOf(stage.Commands, "systemctl restart snap.k8s.etcd.service")
+		apiserverIdx := indexOf(stage.Commands, "systemctl restart snap.k8s.kube-apiserver.service")
+		g.Expect(etcdIdx).To(BeNumerically(">=", 0))
+		g.Expect(apiserverIdx).To(BeNumerically(">", etcdIdx),
+			"etcd must restart before kube-apiserver to preserve the datastore during reconfigure")
+	})
+
+	t.Run("does not restart etcd when no etcd args are set (opt-in)", func(t *testing.T) {
+		stage := getReconfigureServiceRestartStage(nil)
+
+		g.Expect(stage.Commands).NotTo(ContainElement("systemctl restart snap.k8s.etcd.service"))
+		// the kube components are still restarted unconditionally
+		g.Expect(stage.Commands).To(ContainElement("systemctl restart snap.k8s.kube-apiserver.service"))
+	})
+}
+
+func TestGetReconfigureFileStage(t *testing.T) {
+	g := NewWithT(t)
+
+	etcdPath := filepath.Join(domain.KubeComponentsArgsPath, "etcd")
+
+	// getArgs reads each component's existing args file, so seed all of them.
+	// (readServiceArgsFile logrus.Fatals on a missing file.)
+	seedArgsFiles := func(includeEtcd bool) map[string]interface{} {
+		files := map[string]interface{}{
+			filepath.Join(domain.KubeComponentsArgsPath, "kube-apiserver"):          "",
+			filepath.Join(domain.KubeComponentsArgsPath, "kube-controller-manager"): "",
+			filepath.Join(domain.KubeComponentsArgsPath, "kube-scheduler"):          "",
+			filepath.Join(domain.KubeComponentsArgsPath, "kube-proxy"):              "",
+			filepath.Join(domain.KubeComponentsArgsPath, "kubelet"):                 "",
+		}
+		if includeEtcd {
+			files[etcdPath] = "--data-dir=/var/snap/k8s/common/var/lib/etcd/data"
+		}
+		return files
+	}
+
+	t.Run("omits the etcd args file when no etcd args are set (opt-in)", func(t *testing.T) {
+		testFS, cleanup, err := vfst.NewTestFS(seedArgsFiles(false))
+		g.Expect(err).NotTo(HaveOccurred())
+		defer cleanup()
+
+		originalFS := fs.OSFS
+		fs.OSFS = testFS
+		defer func() { fs.OSFS = originalFS }()
+
+		stage := getReconfigureFileStage(nil, nil, nil, nil, nil, nil)
+
+		for _, f := range stage.Files {
+			g.Expect(f.Path).NotTo(Equal(etcdPath), "etcd args file must not be written when feature is unused")
+		}
+		// the five kube component files are always present
+		g.Expect(stage.Files).To(HaveLen(5))
+	})
+
+	t.Run("writes the etcd args file when etcd args are set", func(t *testing.T) {
+		testFS, cleanup, err := vfst.NewTestFS(seedArgsFiles(true))
+		g.Expect(err).NotTo(HaveOccurred())
+		defer cleanup()
+
+		originalFS := fs.OSFS
+		fs.OSFS = testFS
+		defer func() { fs.OSFS = originalFS }()
+
+		metricsURL := "http://0.0.0.0:2381"
+		etcd := map[string]*string{"--listen-metrics-urls": &metricsURL}
+
+		stage := getReconfigureFileStage(nil, nil, nil, nil, nil, etcd)
+
+		g.Expect(stage.Files).To(HaveLen(6))
+		etcdIdx := -1
+		for i, f := range stage.Files {
+			if f.Path == etcdPath {
+				etcdIdx = i
+			}
+		}
+		g.Expect(etcdIdx).To(BeNumerically(">=", 0), "etcd args file must be written when feature is configured")
+		g.Expect(stage.Files[etcdIdx].Content).To(ContainSubstring("--listen-metrics-urls=http://0.0.0.0:2381"))
+	})
+}
+
+func indexOf(haystack []string, needle string) int {
+	for i, s := range haystack {
+		if s == needle {
+			return i
+		}
+	}
+	return -1
+}
+
 func TestContainsAnyNonMatch(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
## Summary
Adds `extra-node-etcd-args` passthrough for Canonical k8s ([PE-9015](https://spectrocloud.atlassian.net/browse/PE-9015)).

- Bump `k8s-snap-api` v1.0.23 → v1.1.0 (adds `ExtraNodeEtcdArgs` on `BootstrapConfig`/`ControlPlaneJoinConfig`). This alone delivers the day-1 path: the field now survives unmarshal→marshal into `bootstrap-config.yaml` / `join-config.yaml`.
- Wire `extra-node-etcd-args` through the control-plane reconfigure path (day-2): write `/var/snap/k8s/common/args/etcd` and restart etcd first.
- **Opt-in:** the etcd args-file write and etcd restart only run when the user sets `extra-node-etcd-args`, so clusters not using the feature see no etcd churn on upgrade. Worker path unchanged (no etcd on workers).

## Test
`go build` · `go test -race ./...` (47 passed) · `golangci-lint` clean.
